### PR TITLE
Upgrade to new CoinMarketCap API

### DIFF
--- a/install.md
+++ b/install.md
@@ -3,6 +3,7 @@
 - get python3. All `python` commands means python3.
 - optional - create and activate [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
 - (sudo) `pip install requests`
+- [get a CoinMarketCap API KEY](https://coinmarketcap.com/api/documentation/v1/#section/Quick-Start-Guide) and hardcode it in `currency_info.py`
 
 # Slack setup
 - `pip install slackclient`


### PR DESCRIPTION
CoinMarketCap API now requires users to register an account (free BASIC account should suffice) and use the API key when [making requests](https://coinmarketcap.com/api/documentation/v1/#section/Quick-Start-Guide)

I've also updated the `install.md` to reflect this change